### PR TITLE
Fix typos

### DIFF
--- a/contracts/interfaces/IPolygonZkEVMErrors.sol
+++ b/contracts/interfaces/IPolygonZkEVMErrors.sol
@@ -135,7 +135,7 @@ interface IPolygonZkEVMErrors {
     error NewPendingStateTimeoutMustBeLower();
 
     /**
-     * @dev Thrown when attempting to set a new multiplier batch fee in a invalid range of values
+     * @dev Thrown when attempting to set a new multiplier batch fee in an invalid range of values
      */
     error InvalidRangeMultiplierBatchFee();
 

--- a/contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol
+++ b/contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol
@@ -35,7 +35,7 @@ contract PolygonZkEVMExistentEtrog is PolygonRollupBaseEtrog {
         hex"df2a8080944d5cf5032b2a844602278b01199ed191a86c93ff8080821092808000000000000000000000000000000000000000000000000000000005ca1ab1e000000000000000000000000000000000000000000000000000000005ca1ab1e01bff";
 
     /**
-     * @dev Emitted when the system is updated to a etrog using this contract, contain the set up etrog transaction
+     * @dev Emitted when the system is updated to an etrog using this contract, contain the set up etrog transaction
      */
     event UpdateEtrogSequence(
         uint64 numBatch,

--- a/contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol
+++ b/contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol
@@ -66,7 +66,7 @@ contract PolygonZkEVMExistentEtrog is PolygonRollupBaseEtrog {
 
     /**
      * note This initializer will be called instead of the PolygonRollupBase
-     * This is a especial initializer since the zkEVM it's an already created network
+     * This is an especial initializer since the zkEVM it's an already created network
      * @param _admin Admin address
      * @param _trustedSequencer Trusted sequencer address
      * @param _trustedSequencerURL Trusted sequencer URL

--- a/contracts/v2/interfaces/IPolygonRollupManager.sol
+++ b/contracts/v2/interfaces/IPolygonRollupManager.sol
@@ -114,7 +114,7 @@ interface IPolygonRollupManager {
     error NewPendingStateTimeoutMustBeLower();
 
     /**
-     * @dev Thrown when attempting to set a new multiplier batch fee in a invalid range of values
+     * @dev Thrown when attempting to set a new multiplier batch fee in an invalid range of values
      */
     error InvalidRangeMultiplierBatchFee();
 

--- a/docs/v2/consensus/validium/migration/PolygonRollupBaseEtrogNoGap.md
+++ b/docs/v2/consensus/validium/migration/PolygonRollupBaseEtrogNoGap.md
@@ -275,7 +275,7 @@ Emitted when the contract is initialized, contain the first sequenced transactio
   )
 ```
 
-Emitted when a aggregator verifies batches
+Emitted when an aggregator verifies batches
 
 ### SetTrustedSequencer
 ```solidity

--- a/docs/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.md
+++ b/docs/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.md
@@ -37,7 +37,7 @@ To enter and exit of the L2 network will be used a PolygonZkEVMBridge smart cont
   ) external
 ```
 note This initializer will be called instead of the PolygonRollupBase
-This is a especial initializer since the zkEVM it's an already created network
+This is an especial initializer since the zkEVM it's an already created network
 
 
 #### Parameters:

--- a/docs/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.md
+++ b/docs/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.md
@@ -56,5 +56,5 @@ This is an especial initializer since the zkEVM it's an already created network
   )
 ```
 
-Emitted when the system is updated to a etrog using this contract, contain the set up etrog transaction
+Emitted when the system is updated to an etrog using this contract, contain the set up etrog transaction
 

--- a/docs/v2/consensus/zkEVM/PolygonZkEVMV2Existent.md
+++ b/docs/v2/consensus/zkEVM/PolygonZkEVMV2Existent.md
@@ -38,7 +38,7 @@ To enter and exit of the L2 network will be used a PolygonZkEVMBridge smart cont
   ) external
 ```
 note This initializer will be called instead of the PolygonRollupBase
-This is a especial initializer since the zkEVM it's an already created network
+This is an especial initializer since the zkEVM it's an already created network
 
 
 #### Parameters:

--- a/docs/v2/lib/PolygonRollupBase.md
+++ b/docs/v2/lib/PolygonRollupBase.md
@@ -254,7 +254,7 @@ Emitted when forced batches are sequenced by not the trusted sequencer
   )
 ```
 
-Emitted when a aggregator verifies batches
+Emitted when an aggregator verifies batches
 
 ### SetTrustedSequencer
 ```solidity


### PR DESCRIPTION
This pull request addresses various typographical errors across smart contract files and documentation. The changes include correcting word usage and improving readability in multiple files.

- Corrected instances of "a etrog" to "an etrog."
- Fixed minor grammar issues and inconsistent phrasing in comments and documentation.
- Updated the documentation to reflect the changes made in the smart contracts.
