### PR TITLE
fix: zkevm-contracts deployment issues

### DIFF
--- a/deployment/v2/4_createRollup.ts
+++ b/deployment/v2/4_createRollup.ts
@@ -584,7 +584,7 @@ async function main() {
             // Get last GER
             const lastGER = await globalExitRootManagerContract.getLastGlobalExitRoot();
 
-            const dataInjectedTx = await polygonZkEVMBridgeContract.interface.encodeFunctionData("initialize", [
+            const dataInjectedTx = await polygonZkEVMBridgeContract.interface.encodeFunctionData("initialize(uint32,address,uint32,address,address,bytes)", [
                 rollupID,
                 gasTokenAddress,
                 gasTokenNetwork,

--- a/tools/createSovereignGenesis/create-sovereign-genesis.ts
+++ b/tools/createSovereignGenesis/create-sovereign-genesis.ts
@@ -188,6 +188,7 @@ async function main() {
         globalExitRootUpdater: createGenesisSovereignParams.globalExitRootUpdater,
         globalExitRootRemover: createGenesisSovereignParams.globalExitRootRemover,
         emergencyBridgePauser: createGenesisSovereignParams.emergencyBridgePauser,
+        proxiedTokensManager: createGenesisSovereignParams.proxiedTokensManager,
     };
 
     logger.info('Update genesis-base to the SovereignContracts');


### PR DESCRIPTION
## Description

The first [fix](https://github.com/agglayer/agglayer-contracts/commit/18a47dbc752ba4c96ad3434a134e5992260f8368) adds the missing proxiedTokensManager property when creating the sovereign genesis. For reference: https://github.com/0xPolygon/kurtosis-cdk/actions/runs/15025224931/job/42224242830?pr=615#step:7:798

The second [fix](https://github.com/agglayer/agglayer-contracts/commit/9145f53179e7ee410563fa8d6648dc59cace6141) updates the bridge initialization call made in the case of pessimistic chains with non vanilla clients (e.g. cdk-erigon). For reference: https://github.com/0xPolygon/kurtosis-cdk/actions/runs/15022595907/job/42215273757