### PR TITLE
fix: bridge initialize

### DIFF
--- a/deployment/v2/4_createRollup.ts
+++ b/deployment/v2/4_createRollup.ts
@@ -586,7 +586,7 @@ async function main() {
             // Get last GER
             const lastGER = await globalExitRootManagerContract.getLastGlobalExitRoot();
 
-            const dataInjectedTx = await polygonZkEVMBridgeContract.interface.encodeFunctionData("initialize", [
+            const dataInjectedTx = await polygonZkEVMBridgeContract.interface.encodeFunctionData("initialize(uint32,address,uint32,address,address,bytes)", [
                 rollupID,
                 gasTokenAddress,
                 gasTokenNetwork,


### PR DESCRIPTION
## Description

`v10.1.0-rc.1` contracts deployment fails in the case of pessimistic rollup and non-vanilla client (e.g. cdk-erigon).

```bash
#######################

Added new Rollup Type deployed
#######################

Created new PolygonPessimisticConsensus Rollup: 0x414e9E227e4b589aF92200508aF5399576530E4e
TypeError: ambiguous function description (i.e. matches \"initialize(address)\", \"initialize(uint32,address,uint32,address,address,bytes)\") (argument=\"key\", value=\"initialize\", code=INVALID_ARGUMENT, version=6.13.4)
    at makeError (/opt/zkevm-contracts/node_modules/ethers/src.ts/utils/errors.ts:687:21)
    at assert (/opt/zkevm-contracts/node_modules/ethers/src.ts/utils/errors.ts:715:25)
    at assertArgument (/opt/zkevm-contracts/node_modules/ethers/src.ts/utils/errors.ts:727:5)
    at Interface.#getFunction (/opt/zkevm-contracts/node_modules/ethers/src.ts/abi/interface.ts:523:31)
    at Interface.getFunction (/opt/zkevm-contracts/node_modules/ethers/src.ts/abi/interface.ts:568:33)
    at Interface.encodeFunctionData (/opt/zkevm-contracts/node_modules/ethers/src.ts/abi/interface.ts:877:28)
    at main (/opt/zkevm-contracts/deployment/v2/4_createRollup.ts:587:79)
    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
  code: 'INVALID_ARGUMENT',
  argument: 'key',
  value: 'initialize',
  shortMessage: 'ambiguous function description (i.e. matches \"initialize(address)\", \"initialize(uint32,address,uint32,address,address,bytes)\")'
}
mv: cannot stat 'deployment/v2/create_rollup_output_*': No such file or directory
\x1b[32m[2025-05-14 13:58:56]\x1b[0m The create_rollup_output.json file was not created after running createRollup
```

It started to fail in kurtosis-cdk because there are two `initialize` methods in the PolygonZkEVMBridgeV2 contract:

- https://github.com/agglayer/agglayer-contracts/blob/v10.1.0-rc.1/contracts/v2/PolygonZkEVMBridgeV2.sol#L200
- https://github.com/agglayer/agglayer-contracts/blob/v10.1.0-rc.1/contracts/v2/PolygonZkEVMBridgeV2.sol#L242
