### PR TITLE
separate functionalities

### DIFF
--- a/contracts/v2/AggLayerGateway.sol
+++ b/contracts/v2/AggLayerGateway.sol
@@ -241,6 +241,8 @@ contract AggLayerGateway is
         if (defaultAggchainVKeys[defaultAggchainSelector] != bytes32(0)) {
             revert AggchainVKeyAlreadyExists();
         }
+
+        // Check new key is non-zero
         if (newAggchainVKey == bytes32(0)) {
             revert VKeyCannotBeZero();
         }
@@ -265,6 +267,11 @@ contract AggLayerGateway is
             revert AggchainVKeyNotFound();
         }
 
+        // Check new key is non-zero
+        if (newDefaultAggchainVKey == bytes32(0)) {
+            revert VKeyCannotBeZero();
+        }
+
         // Update the VKey
         bytes32 previousVKey = defaultAggchainVKeys[defaultAggchainSelector];
         defaultAggchainVKeys[defaultAggchainSelector] = newDefaultAggchainVKey;
@@ -274,6 +281,24 @@ contract AggLayerGateway is
             previousVKey,
             newDefaultAggchainVKey
         );
+    }
+
+    /**
+     * @notice Function to unset a default aggchain verification key from the mapping
+     * @param defaultAggchainSelector The 4 bytes selector to update the default aggchain verification keys.
+     */
+    function unsetDefaultAggchainVKey(
+        bytes4 defaultAggchainSelector
+    ) external onlyRole(AGGCHAIN_DEFAULT_VKEY_ROLE) {
+        // Check if the key exists
+        if (defaultAggchainVKeys[defaultAggchainSelector] == bytes32(0)) {
+            revert AggchainVKeyNotFound();
+        }
+
+        // Set key to zero
+        defaultAggchainVKeys[defaultAggchainSelector] = bytes32(0);
+
+        emit UnsetDefaultAggchainVKey(defaultAggchainSelector);
     }
 
     /**

--- a/contracts/v2/interfaces/IAggLayerGateway.sol
+++ b/contracts/v2/interfaces/IAggLayerGateway.sol
@@ -41,6 +41,12 @@ interface IAggLayerGatewayEvents {
         bytes32 previousVKey,
         bytes32 newVKey
     );
+
+    /**
+     * Emitted when a default aggchain verification key is set to zero
+     * @param selector The 4 bytes selector of the updated default aggchain verification key.
+     */
+    event UnsetDefaultAggchainVKey(bytes4 selector);
 }
 
 /// @dev Extended error events from https://github.com/succinctlabs/sp1-contracts/blob/main/contracts/src/ISP1VerifierGateway.sol

--- a/test/contractsv2/AggLayerGateway.test.ts
+++ b/test/contractsv2/AggLayerGateway.test.ts
@@ -272,7 +272,7 @@ describe("AggLayerGateway tests", () => {
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, "AggchainVKeyAlreadyExists");
     });
 
-    it("getDefaultAggchainVKey & updateDefaultAggchainVKey", async () => {
+    it("getDefaultAggchainVKey & updateDefaultAggchainVKey & unsetDefaultAggchainVKey", async () => {
         // add pessimistic vkey route
         // check onlyRole
         await expect(aggLayerGatewayContract.addDefaultAggchainVKey(selector, pessimisticVKey))
@@ -310,6 +310,10 @@ describe("AggLayerGateway tests", () => {
             .to.be.revertedWithCustomError(aggLayerGatewayContract, "AccessControlUnauthorizedAccount")
             .withArgs(deployer.address, AGGCHAIN_DEFAULT_VKEY_ROLE);
 
+        // check non-zero
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).updateDefaultAggchainVKey(selector, ethers.ZeroHash))
+            .to.be.revertedWithCustomError(aggLayerGatewayContract, "VKeyCannotBeZero")
+
         // check UpdateDefaultAggchainVKey
         await expect(
             aggLayerGatewayContract.connect(aggLayerAdmin).updateDefaultAggchainVKey(selector, newPessimisticVKey)
@@ -319,6 +323,28 @@ describe("AggLayerGateway tests", () => {
 
         // check getDefaultAggchainVKey --> newPessimisticVKey
         expect(await aggLayerGatewayContract.getDefaultAggchainVKey(selector)).to.be.equal(newPessimisticVKey);
+
+        // unset default aggchain vkey
+        // check onlyRole
+        await expect(aggLayerGatewayContract.unsetDefaultAggchainVKey(selector))
+            .to.be.revertedWithCustomError(aggLayerGatewayContract, "AccessControlUnauthorizedAccount")
+            .withArgs(deployer.address, AGGCHAIN_DEFAULT_VKEY_ROLE);
+
+        // check AggchainVKeyNotFound
+        const selector2 = "0x00000002";
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).unsetDefaultAggchainVKey(selector2))
+            .to.be.revertedWithCustomError(aggLayerGatewayContract, "AggchainVKeyNotFound");
+
+        // unset correctly
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).unsetDefaultAggchainVKey(selector))
+            .to.emit(aggLayerGatewayContract, "UnsetDefaultAggchainVKey")
+            .withArgs(selector);
+
+        // check getDefaultAggchainVKey --> ethers.ZeroHash
+        await expect(aggLayerGatewayContract.getDefaultAggchainVKey(selector)).to.be.revertedWithCustomError(
+            aggLayerGatewayContract,
+            "AggchainVKeyNotFound"
+        );
     });
 
     it("verifyPessimisticProof", async () => {

--- a/tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/README.md
+++ b/tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/README.md
@@ -1,0 +1,42 @@
+# Unset Default Aggchain VKey (AggLayerGateway)
+Script to call `unsetDefaultAggchainVKey` function (`AggLayerGateway` contract).
+
+## Setup
+- install packages
+```
+npm i
+```
+
+- Set env variables (not mandatory for network = localhost)
+````
+cp .env.example .env
+````
+
+Fill `.env` with your `INFURA_PROJECT_ID` and `MNEMONIC`
+
+-   Copy configuration files:
+```
+cp ./tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/parameters.json.example ./tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/parameters.json
+```
+
+-  Set your parameters -> parameters.json
+    - `type`: Specify the type of rollup creation, only available:
+        - `EOA`: If creating the rollup from a wallet, the script will execute the creation of the rollup on the specified network
+        - `Multisig`: If creating the rollup from a multisig, the script will output the calldata of the transaction to execute for creating the rollup
+        - `Timelock`: If creating the rollup through a timelock, the script will output the execute and schedule data to send to the timelock contract
+    - `deployerPvtKey`: Not mandatory, used to send tx
+    - `aggLayerGatewayAddress`: Address AggLayerGateway contract
+    - `defaultAggchainSelector`: The 4 bytes selector to add to the default aggchain verification keys
+    - `timelockDelay(optional)`: timelock delay
+    - `timelockSalt(optional)`: timelock salt
+    - `predecessor(optional)`: timelock predecessor
+
+-  Run tool:
+```
+npx hardhat run ./tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/unsetDefaultAggchainVKey.ts --network <network>
+```
+
+### More Info
+- All commands are done from root repository
+- The output files will be saved at `../tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/unset_default_vkey_output_{type}_{date}.json`
+- If the script fails, check the logs, most of the errors are handled and are auto explanatory

--- a/tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/parameters.json.example
+++ b/tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/parameters.json.example
@@ -1,0 +1,6 @@
+{
+    "type": "EOA",
+    "deployerPvtKey": "",
+    "aggLayerGatewayAddress": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+    "defaultAggchainSelector": "0x12340001"
+}

--- a/tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/unsetDefaultAggchainVKey.ts
+++ b/tools/aggLayerGatewayTools/unsetDefaultAggchainVKey/unsetDefaultAggchainVKey.ts
@@ -1,0 +1,203 @@
+import path = require("path");
+import fs = require("fs");
+
+import params from "./parameters.json";
+import {
+  AggLayerGateway,
+} from "../../../typechain-types";
+import {transactionTypes, genOperation} from "../../utils";
+import {decodeScheduleData} from "../../../upgrade/utils";
+import { logger } from "../../../src/logger";
+import { checkParams } from "../../../src/utils";
+
+async function main() {
+    logger.info("Starting tool to unset default vkey to AggLayerGateway contract");
+
+    /////////////////////////////
+    ///        CONSTANTS      ///
+    /////////////////////////////
+    const outputJson = {} as any;
+    const dateStr = new Date().toISOString();
+    const destPath = params.outputPath
+        ? path.join(__dirname, params.outputPath)
+        : path.join(__dirname, `unset_default_vkey_output_${params.type}_${dateStr}.json`);
+
+    const AGGCHAIN_DEFAULT_VKEY_ROLE = ethers.id("AGGCHAIN_DEFAULT_VKEY_ROLE");
+    const DEFAULT_ADMIN_ROLE = ethers.ZeroHash;
+
+    /////////////////////////////
+    ///   CHECK TOOL PARAMS   ///
+    /////////////////////////////
+    logger.info('Check initial parameters');
+
+    const mandatoryParameters = [
+        "type",
+        "aggLayerGatewayAddress",
+        "defaultAggchainSelector"
+    ];
+
+    switch (params.type) {
+        case transactionTypes.EOA:
+        case transactionTypes.MULTISIG:
+            break;
+        case transactionTypes.TIMELOCK:
+            mandatoryParameters.push("timelockDelay");
+            break;
+        default:
+            logger.error(`Invalid type ${params.type}`);
+            process.exit(1);
+    }
+
+    try {
+        checkParams(params, mandatoryParameters);
+    } catch(e) {
+        logger.error(`Error checking parameters. ${e.message}`);
+        process.exit(1);
+    }
+
+    const {
+        type,
+        aggLayerGatewayAddress,
+        defaultAggchainSelector
+    } = params;
+
+    // Load provider
+    logger.info('Load provider');
+    let currentProvider = ethers.provider;
+    if (params.multiplierGas || params.maxFeePerGas) {
+        if (process.env.HARDHAT_NETWORK !== "hardhat") {
+            currentProvider = ethers.getDefaultProvider(
+                `https://${process.env.HARDHAT_NETWORK}.infura.io/v3/${process.env.INFURA_PROJECT_ID}`
+            ) as any;
+            if (params.maxPriorityFeePerGas && params.maxFeePerGas) {
+                logger.info(
+                    `Hardcoded gas used: MaxPriority${params.maxPriorityFeePerGas} gwei, MaxFee${params.maxFeePerGas} gwei`
+                );
+                const FEE_DATA = new ethers.FeeData(
+                    null,
+                    ethers.parseUnits(params.maxFeePerGas, "gwei"),
+                    ethers.parseUnits(params.maxPriorityFeePerGas, "gwei")
+                );
+
+                currentProvider.getFeeData = async () => FEE_DATA;
+            } else {
+                logger.info(`Multiplier gas used: ${params.multiplierGas}`);
+                async function overrideFeeData() {
+                    const feedata = await ethers.provider.getFeeData();
+                    return new ethers.FeeData(
+                        null,
+                        ((feedata.maxFeePerGas as bigint) * BigInt(params.multiplierGas)) / 1000n,
+                        ((feedata.maxPriorityFeePerGas as bigint) * BigInt(params.multiplierGas)) /
+                            1000n
+                    );
+                }
+                currentProvider.getFeeData = overrideFeeData;
+            }
+        }
+    }
+
+    logger.info('Load deployer');
+    // Load deployer
+    let deployer;
+    if (params.deployerPvtKey) {
+        deployer = new ethers.Wallet(params.deployerPvtKey, currentProvider);
+    } else if (process.env.MNEMONIC) {
+        deployer = ethers.HDNodeWallet.fromMnemonic(
+            ethers.Mnemonic.fromPhrase(process.env.MNEMONIC),
+            "m/44'/60'/0'/0/0"
+        ).connect(currentProvider);
+    } else {
+        [deployer] = await ethers.getSigners();
+    }
+
+    logger.info(`Using with: ${deployer.address}`);
+
+    // --network <input>
+    logger.info("Load AggLayerGateway contract");
+    const AggLayerGatewayFactory = await ethers.getContractFactory("AggLayerGateway", deployer);
+    const aggLayerGateway = (await AggLayerGatewayFactory.attach(
+        aggLayerGatewayAddress
+    )) as AggLayerGateway;
+
+    logger.info(`AggLayerGateway address: ${aggLayerGateway.target}`);
+
+    if(type === transactionTypes.TIMELOCK){
+        logger.info("Creating timelock tx to unset default vkey...");
+        const salt = params.timelockSalt || ethers.ZeroHash;
+        const predecessor = params.predecessor || ethers.ZeroHash;
+        const timelockContractFactory = await ethers.getContractFactory("PolygonZkEVMTimelock", deployer);
+        const operation = genOperation(
+            aggLayerGatewayAddress,
+            0, // value
+            AggLayerGatewayFactory.interface.encodeFunctionData("unsetDefaultAggchainVKey", [defaultAggchainSelector]),
+            predecessor, // predecessor
+            salt // salt
+        );
+        // Schedule operation
+        const scheduleData = timelockContractFactory.interface.encodeFunctionData("schedule", [
+            operation.target,
+            operation.value,
+            operation.data,
+            operation.predecessor,
+            operation.salt,
+            params.timelockDelay,
+        ]);
+        // Execute operation
+        const executeData = timelockContractFactory.interface.encodeFunctionData("execute", [
+            operation.target,
+            operation.value,
+            operation.data,
+            operation.predecessor,
+            operation.salt,
+        ]);
+        logger.info(`scheduleData: ${JSON.stringify(scheduleData, null, 2)}`);
+        logger.info(`executeData: ${JSON.stringify(executeData, null, 2)}`);
+        outputJson.scheduleData = scheduleData;
+        outputJson.executeData = executeData;
+        // Decode the scheduleData for better readability
+        outputJson.decodedScheduleData = await decodeScheduleData(scheduleData, AggLayerGatewayFactory);
+    } else if(type === transactionTypes.MULTISIG){
+        logger.info("Creating calldata to unset default vkey from multisig...");
+        const txUnsetDefaultAggchainVKey = AggLayerGatewayFactory.interface.encodeFunctionData("unsetDefaultAggchainVKey", [
+            defaultAggchainSelector
+        ]);
+        outputJson.aggLayerGatewayAddress = aggLayerGatewayAddress;
+        outputJson.defaultAggchainSelector = defaultAggchainSelector;
+        outputJson.txUnsetDefaultAggchainVKey = txUnsetDefaultAggchainVKey;
+    } else {
+        logger.info("Send tx to unset default aggchain vkey...");
+        logger.info("Check deployer role");
+        if ((await aggLayerGateway.hasRole(AGGCHAIN_DEFAULT_VKEY_ROLE, deployer.address)) == false) {
+            if ((await aggLayerGateway.hasRole(DEFAULT_ADMIN_ROLE, deployer.address)) == false) {
+                logger.error("Deployer does not have admin role. Use the test flag on deploy_parameters if this is a test deployment");
+                process.exit(1);
+            }
+            // Grant role AGGCHAIN_DEFAULT_VKEY_ROLE to deployer
+            await aggLayerGateway.grantRole(AGGCHAIN_DEFAULT_VKEY_ROLE, deployer.address);
+        }
+        logger.info("Sending transaction to unset default vkey...");
+        try {
+            const tx = await aggLayerGateway.unsetDefaultAggchainVKey(
+                defaultAggchainSelector
+            );
+            await tx.wait();
+            outputJson.aggLayerGatewayAddress = aggLayerGatewayAddress;
+            outputJson.defaultAggchainSelector = defaultAggchainSelector;
+            outputJson.txHash = tx.hash;
+        } catch(e){
+            logger.error(`Error sending tx: ${e.message}`);
+            process.exit(1);
+        }
+        logger.info("Transaction successful");
+    }
+    // Save output
+    fs.writeFileSync(destPath, JSON.stringify(outputJson, null, 1));
+    logger.info(`Finished script, output saved at: ${destPath}`);
+}
+main().then(() => {
+    process.exit(0);
+}, (err) => {
+    logger.info(err.message);
+    logger.info(err.stack);
+    process.exit(1);
+});


### PR DESCRIPTION
This PR does the following:
- explicitly separates functionalities to update & unset `defaultAggchainVKeys` in two functions in order to emit en specific event for each one and be less error prone