### PR TITLE
minor fix create sovereign genesis

### DIFF
--- a/tools/createSovereignGenesis/create-sovereign-genesis.ts
+++ b/tools/createSovereignGenesis/create-sovereign-genesis.ts
@@ -17,6 +17,7 @@ import { checkParams } from '../../src/utils';
 import { logger } from '../../src/logger';
 import { formatGenesis, getGitInfo } from './helpers';
 import { checkBridgeAddress } from '../utils';
+import { GENESIS_CONTRACT_NAMES } from '../../src/utils-common-aggchain';
 // read files
 import genesisBase from './genesis-base.json';
 import createGenesisSovereignParams from './create-genesis-sovereign-params.json';
@@ -208,7 +209,7 @@ async function main() {
     ) {
         console.log('Rollup with custom gas token, adding WETH address to deployment output...');
         const wethObject = genesisBase.genesis.find(function (obj: { contractName: string }) {
-            return obj.contractName === 'WETH';
+            return obj.contractName === GENESIS_CONTRACT_NAMES.WETH_PROXY;
         });
         outWETHAddress = wethObject.address;
     }
@@ -251,7 +252,7 @@ async function main() {
     if (createGenesisSovereignParams.setTimelockParameters === true) {
         logger.info('Add timelockParameters');
         const timelockContractInfo = finalGenesis.genesis.find(function (obj) {
-            return obj.contractName === 'PolygonZkEVMTimelock';
+            return obj.contractName === GENESIS_CONTRACT_NAMES.POLYGON_TIMELOCK;
         });
 
         const storageTimelock = initializeTimelockStorage(


### PR DESCRIPTION
This pull request updates the `create-sovereign-genesis.ts` script to improve maintainability and consistency by replacing hardcoded contract names with constants from a shared module. The most important changes include importing the `GENESIS_CONTRACT_NAMES` constants and updating references to contract names in the code.

### Refactoring for maintainability:
* [`tools/createSovereignGenesis/create-sovereign-genesis.ts`](diffhunk://#diff-a249921dded8155d9b4633f3beaca509175626931f9b0b8cd13e405c46697085R20): Imported `GENESIS_CONTRACT_NAMES` from `utils-common-aggchain` to replace hardcoded contract names with constants.

### Code consistency improvements:
* [`tools/createSovereignGenesis/create-sovereign-genesis.ts`](diffhunk://#diff-a249921dded8155d9b4633f3beaca509175626931f9b0b8cd13e405c46697085L211-R212): Replaced the hardcoded `'WETH'` contract name with `GENESIS_CONTRACT_NAMES.WETH_PROXY` in the logic for handling custom gas tokens.
* [`tools/createSovereignGenesis/create-sovereign-genesis.ts`](diffhunk://#diff-a249921dded8155d9b4633f3beaca509175626931f9b0b8cd13e405c46697085L254-R255): Replaced the hardcoded `'PolygonZkEVMTimelock'` contract name with `GENESIS_CONTRACT_NAMES.POLYGON_TIMELOCK` in the logic for setting timelock parameters.