### PR TITLE
fetch aggLayerGateway only for aggchains

### DIFF
--- a/tools/addRollupType/addRollupType.ts
+++ b/tools/addRollupType/addRollupType.ts
@@ -139,13 +139,11 @@ async function main() {
     const polygonZkEVMBridgeAddress = await rollupManagerContract.bridgeAddress();
     const polygonZkEVMGlobalExitRootAddress = await rollupManagerContract.globalExitRootManager();
     const polTokenAddress = await rollupManagerContract.pol();
-    const aggLayerGatewayAddress = await rollupManagerContract.aggLayerGateway();
 
     // check all those address are not zero
     expect(polygonZkEVMBridgeAddress).to.not.equal(ethers.ZeroAddress);
     expect(polygonZkEVMGlobalExitRootAddress).to.not.equal(ethers.ZeroAddress);
     expect(polTokenAddress).to.not.equal(ethers.ZeroAddress);
-    expect(aggLayerGatewayAddress).to.not.equal(ethers.ZeroAddress);
 
     let genesis;
     if (!isPessimistic && !AggchainContracts.includes(consensusContract)) {
@@ -244,6 +242,8 @@ async function main() {
                 ]);
             }
         } else {
+            const aggLayerGatewayAddress = await rollupManagerContract.aggLayerGateway();
+
             PolygonConsensusContract = await PolygonConsensusFactory.deploy(
                 polygonZkEVMGlobalExitRootAddress,
                 polTokenAddress,


### PR DESCRIPTION
This pull request makes adjustments to the `tools/addRollupType/addRollupType.ts` script to modify how the `aggLayerGatewayAddress` is handled. Specifically, it removes its initialization and validation in one part of the code and reintroduces its initialization in a different context.

### Changes to `aggLayerGatewayAddress` handling:

* Removed the initialization and validation of `aggLayerGatewayAddress` from the initial setup section of the `main` function. This ensures the address is not unnecessarily checked at the start.
* Reintroduced the initialization of `aggLayerGatewayAddress` later in the `main` function, specifically within a conditional block, aligning its use with the relevant deployment logic.