### PR TITLE
fix initialize rollup tool

### DIFF
--- a/tools/initializeRollup/initializeRollup.ts
+++ b/tools/initializeRollup/initializeRollup.ts
@@ -274,7 +274,7 @@ async function main() {
         process.exit(0);
     } else if (initializeRollupParameters.type === transactionTypes.MULTISIG) {
         console.log('Creating calldata for initializationfrom multisig...');
-        const txDeployRollupCalldata = aggchainContract.interface.encodeFunctionData('initialize', [
+        const txDeployRollupCalldata = aggchainContract.interface.encodeFunctionData('initialize(bytes)', [
             initializeBytesAggchain,
         ]);
 


### PR DESCRIPTION
This pull request includes a modification to the `initializeRollup.ts` file to ensure proper encoding of function data for multisig initialization.

* [`tools/initializeRollup/initializeRollup.ts`](diffhunk://#diff-a928030e4390432c267e0dded42d17ec929855d13129e47e7098100bd6f4a9c3L277-R277): Updated the `encodeFunctionData` method to specify the `bytes` parameter type explicitly in the `initialize` function call, improving clarity and correctness for multisig transaction initialization.