### PR TITLE
Support to use ALGateway for PP consensus

### DIFF
--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -239,9 +239,6 @@ contract PolygonRollupManager is
     // Current rollup manager version
     string public constant ROLLUP_MANAGER_VERSION = "al-v0.3.2";
 
-    // default selector for pessimistic proof at ALGateway, used to force pessimistic consensus chains to use pp from ALGateway-
-    bytes4 public constant DEFAULT_PP_SELECTOR = 0xffff0000;
-
     // Hardcoded address used to indicate that this address triggered in an event should not be considered as valid.
     address private constant _NO_ADDRESS =
         0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
@@ -1333,27 +1330,11 @@ contract PolygonRollupManager is
             aggchainData
         );
 
-        if (rollup.rollupVerifierType == VerifierType.ALGateway) {
-            // Verify proof. The pessimistic proof selector is attached at the first 4 bytes of the proof
-            // proof[0:4]: 4 bytes selector pp
-            // proof[4:8]: 4 bytes selector SP1 verifier
-            // proof[8:]: proof
-            aggLayerGateway.verifyPessimisticProof(
-                inputPessimisticBytes,
-                proof
-            );
-        } else {
-            // Append the default PP selector to the proof
-            // proof[0:4]: 4 bytes selector pp
-            bytes memory proofWithPPSelector = abi.encodePacked(
-                DEFAULT_PP_SELECTOR,
-                proof
-            );
-            aggLayerGateway.verifyPessimisticProof(
-                inputPessimisticBytes,
-                proofWithPPSelector
-            );
-        }
+        // Verify proof. The pessimistic proof selector is attached at the first 4 bytes of the proof
+        // proof[0:4]: 4 bytes selector pp
+        // proof[4:8]: 4 bytes selector SP1 verifier
+        // proof[8:]: proof
+        aggLayerGateway.verifyPessimisticProof(inputPessimisticBytes, proof);
 
         // Update aggregation parameters
         lastAggregationTimestamp = uint64(block.timestamp);

--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -237,7 +237,10 @@ contract PolygonRollupManager is
         keccak256("EMERGENCY_COUNCIL_ADMIN");
 
     // Current rollup manager version
-    string public constant ROLLUP_MANAGER_VERSION = "al-v0.3.1";
+    string public constant ROLLUP_MANAGER_VERSION = "al-v0.3.2";
+
+    // default selector for pessimistic proof at ALGateway, used to force pessimistic consensus chains to use pp from ALGateway-
+    bytes4 public constant DEFAULT_PP_SELECTOR = 0xffff0000;
 
     // Hardcoded address used to indicate that this address triggered in an event should not be considered as valid.
     address private constant _NO_ADDRESS =
@@ -410,11 +413,6 @@ contract PolygonRollupManager is
     event SetBatchFee(uint256 newBatchFee);
 
     /**
-     * @dev Emitted when rollup manager is upgraded
-     */
-    event UpdateRollupManagerVersion(string rollupManagerVersion);
-
-    /**
      * @notice Emitted when a ALGateway or Pessimistic chain verifies a pessimistic proof
      * @param rollupID Rollup ID
      * @param prevPessimisticRoot Previous pessimistic root
@@ -492,9 +490,7 @@ contract PolygonRollupManager is
     /**
      * Initializer function to set new rollup manager version
      */
-    function initialize() external virtual reinitializer(5) {
-        emit UpdateRollupManagerVersion(ROLLUP_MANAGER_VERSION);
-    }
+    function initialize() external virtual reinitializer(5) {}
 
     ///////////////////////////////////////
     // Rollups management functions
@@ -1347,11 +1343,15 @@ contract PolygonRollupManager is
                 proof
             );
         } else {
-            // Verify proof
-            ISP1Verifier(rollup.verifier).verifyProof(
-                rollup.programVKey,
-                inputPessimisticBytes,
+            // Append the default PP selector to the proof
+            // proof[0:4]: 4 bytes selector pp
+            bytes memory proofWithPPSelector = abi.encodePacked(
+                DEFAULT_PP_SELECTOR,
                 proof
+            );
+            aggLayerGateway.verifyPessimisticProof(
+                inputPessimisticBytes,
+                proofWithPPSelector
             );
         }
 

--- a/contracts/v2/mocks/PolygonRollupManagerMock.sol
+++ b/contracts/v2/mocks/PolygonRollupManagerMock.sol
@@ -76,7 +76,6 @@ contract PolygonRollupManagerMock is PolygonRollupManager {
         // Since it's mock, use admin for everything
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
-        emit UpdateRollupManagerVersion(ROLLUP_MANAGER_VERSION);
     }
 
     function prepareMockCalculateRoot(bytes32[] memory localExitRoots) public {

--- a/test/contractsv2/PolygonRollupManager-Pessimistic.test.ts
+++ b/test/contractsv2/PolygonRollupManager-Pessimistic.test.ts
@@ -44,7 +44,6 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
 
     const PESSIMISTIC_SELECTOR = '0x00000001';
     const randomPessimisticVKey = computeRandomBytes(32);
-    const randomPessimisticDefaultVKey = computeRandomBytes(32);
 
     // Bridge constants
     const networkIDMainnet = 0;
@@ -157,16 +156,6 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
         })) as unknown as PolygonRollupManagerMock;
 
         await rollupManagerContract.waitForDeployment();
-
-        // Add default pp key to ALGateway
-        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
-        await expect(
-            aggLayerGatewayContract
-                .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
-        )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,
@@ -820,7 +809,7 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
         const unexistentL1InfoTreeCount = 2;
         const newLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const newPPRoot = '0x0000000000000000000000000000000000000000000000000000000000000002';
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}00`;
 
         // not trusted aggregator
         await expect(

--- a/test/contractsv2/PolygonRollupManagerAL-ECDSA.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-ECDSA.test.ts
@@ -68,6 +68,7 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA', () => {
     const randomNewStateRoot = computeRandomBytes(32);
     const CUSTOM_DATA_ECDSA = encodeAggchainDataECDSA(AGGCHAIN_VKEY_SELECTOR, randomNewStateRoot);
     const randomPessimisticVKey = computeRandomBytes(32);
+    const randomPessimisticDefaultVKey = computeRandomBytes(32);
 
     upgrades.silenceWarnings();
 
@@ -276,6 +277,16 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA', () => {
 
         // check precalculated address
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);
+
+        // Add default pp key to ALGateway
+        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
+        await expect(
+            aggLayerGatewayContract
+                .connect(aggLayerAdmin)
+                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
+        )
+            .to.emit(aggLayerGatewayContract, 'RouteAdded')
+            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         await polygonZkEVMBridgeContract.initialize(
             NETWORK_ID_MAINNET,

--- a/test/contractsv2/PolygonRollupManagerAL-ECDSA.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-ECDSA.test.ts
@@ -68,7 +68,6 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA', () => {
     const randomNewStateRoot = computeRandomBytes(32);
     const CUSTOM_DATA_ECDSA = encodeAggchainDataECDSA(AGGCHAIN_VKEY_SELECTOR, randomNewStateRoot);
     const randomPessimisticVKey = computeRandomBytes(32);
-    const randomPessimisticDefaultVKey = computeRandomBytes(32);
 
     upgrades.silenceWarnings();
 
@@ -277,16 +276,6 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA', () => {
 
         // check precalculated address
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);
-
-        // Add default pp key to ALGateway
-        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
-        await expect(
-            aggLayerGatewayContract
-                .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
-        )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         await polygonZkEVMBridgeContract.initialize(
             NETWORK_ID_MAINNET,
@@ -649,7 +638,7 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA', () => {
         // check JS function computeInputPessimisticBytes
         const newLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const newPPRoot = '0x0000000000000000000000000000000000000000000000000000000000000002';
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}00`;
 
         // verify pessimistic from the created pessimistic rollup
         await expect(

--- a/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
@@ -70,7 +70,6 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
     const aggchainVKeySelector = '0x12340001';
     const CUSTOM_DATA_FEP = encodeAggchainDataFEP(aggchainVKeySelector, newStateRoot, newl2BlockNumber);
     const randomPessimisticVKey = computeRandomBytes(32);
-    const randomPessimisticDefaultVKey = computeRandomBytes(32);
     let initParams;
 
     upgrades.silenceWarnings();
@@ -289,16 +288,6 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
 
         // check precalculated address
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);
-
-        // Add default pp key to ALGateway
-        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
-        await expect(
-            aggLayerGatewayContract
-                .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
-        )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         await polygonZkEVMBridgeContract.initialize(
             NETWORK_ID_MAINNET,
@@ -670,7 +659,7 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
         // check JS function computeInputPessimisticBytes
         const newLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const newPPRoot = '0x0000000000000000000000000000000000000000000000000000000000000002';
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}00`;
 
         // verify pessimistic from the created pessimistic rollup
         await expect(

--- a/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
@@ -70,6 +70,7 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
     const aggchainVKeySelector = '0x12340001';
     const CUSTOM_DATA_FEP = encodeAggchainDataFEP(aggchainVKeySelector, newStateRoot, newl2BlockNumber);
     const randomPessimisticVKey = computeRandomBytes(32);
+    const randomPessimisticDefaultVKey = computeRandomBytes(32);
     let initParams;
 
     upgrades.silenceWarnings();
@@ -288,6 +289,16 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
 
         // check precalculated address
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);
+
+        // Add default pp key to ALGateway
+        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
+        await expect(
+            aggLayerGatewayContract
+                .connect(aggLayerAdmin)
+                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
+        )
+            .to.emit(aggLayerGatewayContract, 'RouteAdded')
+            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         await polygonZkEVMBridgeContract.initialize(
             NETWORK_ID_MAINNET,

--- a/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
@@ -28,7 +28,6 @@ import {
 } from '../../src/utils-aggchain-ECDSA';
 
 const randomPessimisticVKey = computeRandomBytes(32);
-const randomPessimisticDefaultVKey = computeRandomBytes(32);
 
 describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
     // SIGNERS
@@ -289,16 +288,6 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
         // check precalculated address
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);
 
-        // Add default pp key to ALGateway
-        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
-        await expect(
-            aggLayerGatewayContract
-                .connect(addPPRoute)
-                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
-        )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
-
         await polygonZkEVMBridgeContract.initialize(
             NETWORK_ID_MAINNET,
             ethers.ZeroAddress, // zero for ether
@@ -544,7 +533,7 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
         // check JS function computeInputPessimisticBytes
         const newLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const newPPRoot = '0x0000000000000000000000000000000000000000000000000000000000000002';
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}10000000`;
 
         // verify pessimistic from the created pessimistic rollup
         await expect(

--- a/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
@@ -83,7 +83,7 @@ describe('Polygon Rollup manager upgraded', () => {
     let polygonZkEVMGlobalExitRoot: PolygonZkEVMGlobalExitRootV2;
     let rollupManagerContract: PolygonRollupManagerMock;
 
-    const latestVersionRollupManager = 'al-v0.3.1';
+    const latestVersionRollupManager = 'al-v0.3.2';
     const polTokenName = 'POL Token';
     const polTokenSymbol = 'POL';
     const polTokenInitialBalance = ethers.parseEther('20000000');

--- a/test/contractsv2/UpgradeToPP.test.ts
+++ b/test/contractsv2/UpgradeToPP.test.ts
@@ -28,6 +28,7 @@ describe('Upgradeable to PPV2', () => {
     let trustedSequencer: any;
     let admin: any;
     let beneficiary: any;
+    let aggLayerAdmin: any;
 
     let polTokenContract: ERC20PermitMock;
     let PolygonPPConsensusContract: PolygonPessimisticConsensus;
@@ -43,6 +44,9 @@ describe('Upgradeable to PPV2', () => {
     const polTokenName = 'POL Token';
     const polTokenSymbol = 'POL';
     const polTokenInitialBalance = ethers.parseEther('20000000');
+    const PESSIMISTIC_SELECTOR = '0x00000001';
+    const randomPessimisticVKey = computeRandomBytes(32);
+    const randomPessimisticDefaultVKey = computeRandomBytes(32);
 
     const rollupTypeIDPessimistic = 1;
 
@@ -50,7 +54,7 @@ describe('Upgradeable to PPV2', () => {
         upgrades.silenceWarnings();
 
         // load signers
-        [deployer, trustedAggregator, trustedSequencer, admin, timelock, emergencyCouncil, beneficiary] =
+        [deployer, trustedAggregator, trustedSequencer, admin, timelock, emergencyCouncil, beneficiary, aggLayerAdmin] =
             await ethers.getSigners();
 
         // deploy mock verifier
@@ -83,6 +87,16 @@ describe('Upgradeable to PPV2', () => {
             unsafeAllow: ['constructor'],
         });
 
+        // Initialize aggLayerGateway
+        await aggLayerGatewayContract.initialize(
+            admin.address,
+            aggLayerAdmin.address,
+            aggLayerAdmin.address,
+            aggLayerAdmin.address,
+            PESSIMISTIC_SELECTOR,
+            verifierContract.target,
+            randomPessimisticVKey,
+        );
         const nonceProxyBridge =
             Number(await ethers.provider.getTransactionCount(deployer.address)) + (firstDeployment ? 3 : 2);
 
@@ -152,6 +166,16 @@ describe('Upgradeable to PPV2', () => {
             timelock.address,
             emergencyCouncil.address,
         );
+
+        // Add default pp key to ALGateway
+        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
+        await expect(
+            aggLayerGatewayContract
+                .connect(aggLayerAdmin)
+                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
+        )
+            .to.emit(aggLayerGatewayContract, 'RouteAdded')
+            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         // fund sequencer address with Matic tokens
         await polTokenContract.transfer(trustedSequencer.address, ethers.parseEther('1000'));

--- a/test/contractsv2/UpgradeToPP.test.ts
+++ b/test/contractsv2/UpgradeToPP.test.ts
@@ -46,7 +46,6 @@ describe('Upgradeable to PPV2', () => {
     const polTokenInitialBalance = ethers.parseEther('20000000');
     const PESSIMISTIC_SELECTOR = '0x00000001';
     const randomPessimisticVKey = computeRandomBytes(32);
-    const randomPessimisticDefaultVKey = computeRandomBytes(32);
 
     const rollupTypeIDPessimistic = 1;
 
@@ -166,16 +165,6 @@ describe('Upgradeable to PPV2', () => {
             timelock.address,
             emergencyCouncil.address,
         );
-
-        // Add default pp key to ALGateway
-        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
-        await expect(
-            aggLayerGatewayContract
-                .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey),
-        )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(defaultSelector, verifierContract.target, randomPessimisticDefaultVKey);
 
         // fund sequencer address with Matic tokens
         await polTokenContract.transfer(trustedSequencer.address, ethers.parseEther('1000'));
@@ -410,7 +399,7 @@ describe('Upgradeable to PPV2', () => {
         const newWrongLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const lastLER = rollupData[4];
         const newPPRoot = computeRandomBytes(32);
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}00`;
 
         await expect(
             rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(
@@ -696,7 +685,7 @@ describe('Upgradeable to PPV2', () => {
         const newWrongLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const lastLER = rollupData[4];
         const newPPRoot = computeRandomBytes(32);
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}00`;
 
         await expect(
             rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(
@@ -1035,7 +1024,7 @@ describe('Upgradeable to PPV2', () => {
         const newWrongLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const lastLER = rollupData[4];
         const newPPRoot = computeRandomBytes(32);
-        const proofPP = '0x00';
+        const proofPP = `${PESSIMISTIC_SELECTOR}00`;
 
         await expect(
             rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(

--- a/test/contractsv2/real-prover-sp1/e2e-verify-proof.test.ts
+++ b/test/contractsv2/real-prover-sp1/e2e-verify-proof.test.ts
@@ -39,7 +39,7 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
     const polTokenSymbol = 'POL';
     const polTokenInitialBalance = ethers.parseEther('20000000');
     const PESSIMISTIC_SELECTOR = '0x00000001';
-    const randomPessimisticVKey = computeRandomBytes(32);
+    const programVKey = inputProof.vkey;
 
     // BRidge constants
     const networkIDMainnet = 0;
@@ -105,7 +105,7 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
             aggLayerAdmin.address,
             PESSIMISTIC_SELECTOR,
             verifierContract.target,
-            randomPessimisticVKey,
+            programVKey,
         );
 
         const nonceProxyBridge =
@@ -156,16 +156,6 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
         // check precalculated address
         expect(precalculateBridgeAddress).to.be.equal(polygonZkEVMBridgeContract.target);
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);
-
-        // Add default pp key to ALGateway
-        const defaultSelector = await rollupManagerContract.DEFAULT_PP_SELECTOR();
-        await expect(
-            aggLayerGatewayContract
-                .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(defaultSelector, verifierContract.target, inputProof.vkey),
-        )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(defaultSelector, verifierContract.target, inputProof.vkey);
 
         await polygonZkEVMBridgeContract.initialize(
             networkIDMainnet,
@@ -236,7 +226,6 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
         const forkID = 11; // just metadata for pessimistic consensus
         const genesis = ethers.ZeroHash;
         const description = 'new pessimistic consensus';
-        const programVKey = inputProof.vkey;
         const rollupTypeID = 1;
 
         // correct add new rollup via timelock
@@ -277,7 +266,7 @@ describe('Polygon Rollup Manager with Polygon Pessimistic Consensus', () => {
         const l1InfoTreeLeafCount = 2;
         const newLER = inputProof['pp-inputs']['new-local-exit-root'];
         const newPPRoot = inputProof['pp-inputs']['new-pessimistic-root'];
-        const proofPP = inputProof.proof;
+        const proofPP = `${PESSIMISTIC_SELECTOR}${inputProof.proof.slice(2)}`;
 
         // not trusted aggregator
         await expect(


### PR DESCRIPTION
Small tweak at rollup manager to use ALGateway to retrieve pp keys for pessimistic chains verifications.

1- Remove condition
````
        if (rollup.rollupVerifierType == VerifierType.ALGateway) {
            // Verify proof. The pessimistic proof selector is attached at the first 4 bytes of the proof
            // proof[0:4]: 4 bytes selector pp
            // proof[4:8]: 4 bytes selector SP1 verifier
            // proof[8:]: proof
            aggLayerGateway.verifyPessimisticProof(
                inputPessimisticBytes,
                proof
            );
        } else {
            // Verify proof
            ISP1Verifier(rollup.verifier).verifyProof(
                rollup.programVKey,
                inputPessimisticBytes,
                proof
            );
        }
````
Set it to 
````
            aggLayerGateway.verifyPessimisticProof(
                inputPessimisticBytes,
                proof
            );
`````
2- Add selector to agglayer node
3- Upgrade rollup manager
Careful: Contract upgrade will have to be coordinated with agglayer upgrade

Advantages:
- Low changes on smart contracts 

Disadvantatges:
- Can't remove pessimistic logic from code
- Contracts upgrade will have to be coordinated with agglayer upgrade
- Agglayer to add a selector on pp proofs
- Need to upgrade rollups