### PR TITLE
L2OO v3

### DIFF
--- a/contracts/v2/aggchains/AggchainFEP.sol
+++ b/contracts/v2/aggchains/AggchainFEP.sol
@@ -658,7 +658,7 @@ contract AggchainFEP is AggchainBase {
         bytes32 _rollupConfigHash,
         bytes32 _aggregationVkey,
         bytes32 _rangeVkeyCommitment
-    ) external onlyOwner {
+    ) external onlyRollupManager {
         require(_configName != bytes32(0), "L2OutputOracle: config name cannot be empty");
         require(!isValidOpSuccinctConfig(opSuccinctConfigs[_configName]), "L2OutputOracle: config already exists");
 

--- a/contracts/v2/aggchains/AggchainFEP.sol
+++ b/contracts/v2/aggchains/AggchainFEP.sol
@@ -69,7 +69,7 @@ contract AggchainFEP is AggchainBase {
 
     /// @notice Op L2OO Semantic version.
     /// @custom:semver v3.0.0-rc1
-    string public constant version = "v3.0.0-rc1";
+    string public constant AGGCHAIN_FEP_VERSION = "v3.0.0-rc1";
 
     ////////////////////////////////////////////////////////////
     //                       Storage                          //
@@ -118,7 +118,8 @@ contract AggchainFEP is AggchainBase {
     mapping(bytes32 => OpSuccinctConfig) public opSuccinctConfigs;
 
     /// @notice The genesis configuration name.
-    bytes32 public constant GENESIS_CONFIG_NAME = keccak256("opsuccinct_genesis");
+    bytes32 public constant GENESIS_CONFIG_NAME =
+        keccak256("opsuccinct_genesis");
 
     ////////////////////////////////////////////////////////////
     //                         Events                         //
@@ -196,7 +197,10 @@ contract AggchainFEP is AggchainBase {
     /// @param rangeVkeyCommitment The range verification key commitment.
     /// @param rollupConfigHash The rollup config hash.
     event OpSuccinctConfigUpdated(
-        bytes32 indexed configName, bytes32 aggregationVkey, bytes32 rangeVkeyCommitment, bytes32 rollupConfigHash
+        bytes32 indexed configName,
+        bytes32 aggregationVkey,
+        bytes32 rangeVkeyCommitment,
+        bytes32 rollupConfigHash
     );
 
     /// @notice Emitted when an OP Succinct configuration is deleted.
@@ -643,9 +647,13 @@ contract AggchainFEP is AggchainBase {
     /// @notice Validates that an OpSuccinctConfig has all non-zero parameters.
     /// @param _config The OpSuccinctConfig to validate.
     /// @return True if all parameters are non-zero, false otherwise.
-    function isValidOpSuccinctConfig(OpSuccinctConfig memory _config) public pure returns (bool) {
-        return _config.aggregationVkey != bytes32(0) && _config.rangeVkeyCommitment != bytes32(0)
-            && _config.rollupConfigHash != bytes32(0);
+    function isValidOpSuccinctConfig(
+        OpSuccinctConfig memory _config
+    ) public pure returns (bool) {
+        return
+            _config.aggregationVkey != bytes32(0) &&
+            _config.rangeVkeyCommitment != bytes32(0) &&
+            _config.rollupConfigHash != bytes32(0);
     }
 
     /// @notice Updates or creates an OP Succinct configuration.
@@ -659,8 +667,14 @@ contract AggchainFEP is AggchainBase {
         bytes32 _aggregationVkey,
         bytes32 _rangeVkeyCommitment
     ) external onlyAggchainManager {
-        require(_configName != bytes32(0), "L2OutputOracle: config name cannot be empty");
-        require(!isValidOpSuccinctConfig(opSuccinctConfigs[_configName]), "L2OutputOracle: config already exists");
+        require(
+            _configName != bytes32(0),
+            "L2OutputOracle: config name cannot be empty"
+        );
+        require(
+            !isValidOpSuccinctConfig(opSuccinctConfigs[_configName]),
+            "L2OutputOracle: config already exists"
+        );
 
         OpSuccinctConfig memory newConfig = OpSuccinctConfig({
             aggregationVkey: _aggregationVkey,
@@ -668,16 +682,26 @@ contract AggchainFEP is AggchainBase {
             rollupConfigHash: _rollupConfigHash
         });
 
-        require(isValidOpSuccinctConfig(newConfig), "L2OutputOracle: invalid OP Succinct configuration parameters");
+        require(
+            isValidOpSuccinctConfig(newConfig),
+            "L2OutputOracle: invalid OP Succinct configuration parameters"
+        );
 
         opSuccinctConfigs[_configName] = newConfig;
 
-        emit OpSuccinctConfigUpdated(_configName, _aggregationVkey, _rangeVkeyCommitment, _rollupConfigHash);
+        emit OpSuccinctConfigUpdated(
+            _configName,
+            _aggregationVkey,
+            _rangeVkeyCommitment,
+            _rollupConfigHash
+        );
     }
 
     /// @notice Deletes an OP Succinct configuration.
     /// @param _configName The name of the configuration to delete.
-    function deleteOpSuccinctConfig(bytes32 _configName) external onlyAggchainManager {
+    function deleteOpSuccinctConfig(
+        bytes32 _configName
+    ) external onlyAggchainManager {
         delete opSuccinctConfigs[_configName];
         emit OpSuccinctConfigDeleted(_configName);
     }

--- a/contracts/v2/aggchains/AggchainFEP.sol
+++ b/contracts/v2/aggchains/AggchainFEP.sol
@@ -658,7 +658,7 @@ contract AggchainFEP is AggchainBase {
         bytes32 _rollupConfigHash,
         bytes32 _aggregationVkey,
         bytes32 _rangeVkeyCommitment
-    ) external onlyRollupManager {
+    ) external onlyAggchainManager {
         require(_configName != bytes32(0), "L2OutputOracle: config name cannot be empty");
         require(!isValidOpSuccinctConfig(opSuccinctConfigs[_configName]), "L2OutputOracle: config already exists");
 
@@ -677,7 +677,7 @@ contract AggchainFEP is AggchainBase {
 
     /// @notice Deletes an OP Succinct configuration.
     /// @param _configName The name of the configuration to delete.
-    function deleteOpSuccinctConfig(bytes32 _configName) external onlyOwner {
+    function deleteOpSuccinctConfig(bytes32 _configName) external onlyAggchainManager {
         delete opSuccinctConfigs[_configName];
         emit OpSuccinctConfigDeleted(_configName);
     }

--- a/contracts/v2/aggchains/AggchainFEP.sol
+++ b/contracts/v2/aggchains/AggchainFEP.sol
@@ -659,7 +659,7 @@ contract AggchainFEP is AggchainBase {
         bytes32 _aggregationVkey,
         bytes32 _rangeVkeyCommitment
     ) external onlyOwner {
-        require(_configName != bytes32(0), "L2OutputOracle: config name cannot be empty");Expand commentComment on line R543ResolvedCode has comments. Press enter to view.
+        require(_configName != bytes32(0), "L2OutputOracle: config name cannot be empty");
         require(!isValidOpSuccinctConfig(opSuccinctConfigs[_configName]), "L2OutputOracle: config already exists");
 
         OpSuccinctConfig memory newConfig = OpSuccinctConfig({

--- a/contracts/v2/aggchains/AggchainFEP.sol
+++ b/contracts/v2/aggchains/AggchainFEP.sol
@@ -38,6 +38,19 @@ contract AggchainFEP is AggchainBase {
         uint128 l2BlockNumber;
     }
 
+    /// @notice Configuration parameters for OP Succinct verification.
+    struct OpSuccinctConfig {
+        /// @notice The verification key of the aggregation SP1 program.
+        bytes32 aggregationVkey;
+        /// @notice The 32 byte commitment to the BabyBear representation of the verification key of
+        /// the range SP1 program. Specifically, this verification key is the output of converting
+        /// the [u32; 8] range BabyBear verification key to a [u8; 32] array.
+        bytes32 rangeVkeyCommitment;
+        /// @notice The hash of the chain's rollup config, which ensures the proofs submitted are for
+        /// the correct chain. This is used to prevent replay attacks.
+        bytes32 rollupConfigHash;
+    }
+
     ////////////////////////////////////////////////////////////
     //                  Transient Storage                     //
     ////////////////////////////////////////////////////////////
@@ -55,8 +68,8 @@ contract AggchainFEP is AggchainBase {
     bytes2 public constant AGGCHAIN_TYPE = 0x0001;
 
     /// @notice Op L2OO Semantic version.
-    /// @custom:semver v2.0.0
-    string public constant AGGCHAIN_FEP_VERSION = "v2.0.0";
+    /// @custom:semver v3.0.0-rc1
+    string public constant version = "v3.0.0-rc1";
 
     ////////////////////////////////////////////////////////////
     //                       Storage                          //
@@ -100,6 +113,12 @@ contract AggchainFEP is AggchainBase {
 
     /// @notice This account will be able to accept the optimisticModeManager role
     address public pendingOptimisticModeManager;
+
+    /// @notice Mapping of configuration names to OpSuccinctConfig structs.
+    mapping(bytes32 => OpSuccinctConfig) public opSuccinctConfigs;
+
+    /// @notice The genesis configuration name.
+    bytes32 public constant GENESIS_CONFIG_NAME = keccak256("opsuccinct_genesis");
 
     ////////////////////////////////////////////////////////////
     //                         Events                         //
@@ -170,6 +189,19 @@ contract AggchainFEP is AggchainBase {
         bytes32 indexed oldRangeVkeyCommitment,
         bytes32 indexed newRangeVkeyCommitment
     );
+
+    /// @notice Emitted when an OP Succinct configuration is updated.
+    /// @param configName The name of the configuration.
+    /// @param aggregationVkey The aggregation verification key.
+    /// @param rangeVkeyCommitment The range verification key commitment.
+    /// @param rollupConfigHash The rollup config hash.
+    event OpSuccinctConfigUpdated(
+        bytes32 indexed configName, bytes32 aggregationVkey, bytes32 rangeVkeyCommitment, bytes32 rollupConfigHash
+    );
+
+    /// @notice Emitted when an OP Succinct configuration is deleted.
+    /// @param configName The name of the configuration that was deleted.
+    event OpSuccinctConfigDeleted(bytes32 indexed configName);
 
     ////////////////////////////////////////////////////////////
     //                         Errors                         //
@@ -329,6 +361,13 @@ contract AggchainFEP is AggchainBase {
                 _initAggchainVKeySelector,
                 _vKeyManager
             );
+
+            // Initialize genesis configuration
+            opSuccinctConfigs[GENESIS_CONFIG_NAME] = OpSuccinctConfig({
+                aggregationVkey: _initParams.aggregationVkey,
+                rangeVkeyCommitment: _initParams.rangeVkeyCommitment,
+                rollupConfigHash: _initParams.rollupConfigHash
+            });
         } else if (_initializerVersion == 1) {
             // contract has been previously initialized with all parameters in the PolygonConsensusBase.sol
             // Only initialize the FEP and AggchainBase params
@@ -599,6 +638,48 @@ contract AggchainFEP is AggchainBase {
                 l2BlockNumber: uint128(_l2BlockNumber)
             })
         );
+    }
+
+    /// @notice Validates that an OpSuccinctConfig has all non-zero parameters.
+    /// @param _config The OpSuccinctConfig to validate.
+    /// @return True if all parameters are non-zero, false otherwise.
+    function isValidOpSuccinctConfig(OpSuccinctConfig memory _config) public pure returns (bool) {
+        return _config.aggregationVkey != bytes32(0) && _config.rangeVkeyCommitment != bytes32(0)
+            && _config.rollupConfigHash != bytes32(0);
+    }
+
+    /// @notice Updates or creates an OP Succinct configuration.
+    /// @param _configName The name of the configuration.
+    /// @param _rollupConfigHash The rollup config hash.
+    /// @param _aggregationVkey The aggregation verification key.
+    /// @param _rangeVkeyCommitment The range verification key commitment.
+    function addOpSuccinctConfig(
+        bytes32 _configName,
+        bytes32 _rollupConfigHash,
+        bytes32 _aggregationVkey,
+        bytes32 _rangeVkeyCommitment
+    ) external onlyOwner {
+        require(_configName != bytes32(0), "L2OutputOracle: config name cannot be empty");Expand commentComment on line R543ResolvedCode has comments. Press enter to view.
+        require(!isValidOpSuccinctConfig(opSuccinctConfigs[_configName]), "L2OutputOracle: config already exists");
+
+        OpSuccinctConfig memory newConfig = OpSuccinctConfig({
+            aggregationVkey: _aggregationVkey,
+            rangeVkeyCommitment: _rangeVkeyCommitment,
+            rollupConfigHash: _rollupConfigHash
+        });
+
+        require(isValidOpSuccinctConfig(newConfig), "L2OutputOracle: invalid OP Succinct configuration parameters");
+
+        opSuccinctConfigs[_configName] = newConfig;
+
+        emit OpSuccinctConfigUpdated(_configName, _aggregationVkey, _rangeVkeyCommitment, _rollupConfigHash);
+    }
+
+    /// @notice Deletes an OP Succinct configuration.
+    /// @param _configName The name of the configuration to delete.
+    function deleteOpSuccinctConfig(bytes32 _configName) external onlyOwner {
+        delete opSuccinctConfigs[_configName];
+        emit OpSuccinctConfigDeleted(_configName);
     }
 
     ////////////////////////////////////////////////////////


### PR DESCRIPTION
This pull request introduces significant updates to the `AggchainFEP` contract, primarily focusing on adding support for OP Succinct configurations. Key changes include the introduction of a new configuration struct, associated mappings, events, and management functions, as well as a version bump to indicate these updates.

### New OP Succinct Configuration Support:

* Added a new `OpSuccinctConfig` struct to define configuration parameters for OP Succinct verification, including fields for `aggregationVkey`, `rangeVkeyCommitment`, and `rollupConfigHash`. (`[contracts/v2/aggchains/AggchainFEP.solR41-R53](diffhunk://#diff-45e941cbaab601c4df8af599b2c32e5726bc33b6781b6753aead91c9b80bbb3dR41-R53)`)
* Introduced a public mapping `opSuccinctConfigs` to store configurations by name, and a constant `GENESIS_CONFIG_NAME` for the initial configuration. (`[contracts/v2/aggchains/AggchainFEP.solR117-R122](diffhunk://#diff-45e941cbaab601c4df8af599b2c32e5726bc33b6781b6753aead91c9b80bbb3dR117-R122)`)
* Added events `OpSuccinctConfigUpdated` and `OpSuccinctConfigDeleted` to track configuration changes. (`[contracts/v2/aggchains/AggchainFEP.solR193-R205](diffhunk://#diff-45e941cbaab601c4df8af599b2c32e5726bc33b6781b6753aead91c9b80bbb3dR193-R205)`)
* Implemented functions `addOpSuccinctConfig` and `deleteOpSuccinctConfig` to manage configurations, with validation logic to ensure parameters are non-zero. (`[contracts/v2/aggchains/AggchainFEP.solR643-R684](diffhunk://#diff-45e941cbaab601c4df8af599b2c32e5726bc33b6781b6753aead91c9b80bbb3dR643-R684)`)

### Initialization Enhancements:

* Updated the contract initializer to set up the genesis OP Succinct configuration using provided parameters. (`[contracts/v2/aggchains/AggchainFEP.solR364-R370](diffhunk://#diff-45e941cbaab601c4df8af599b2c32e5726bc33b6781b6753aead91c9b80bbb3dR364-R370)`)

### Version Update:

* Updated the semantic version of the contract from `v2.0.0` to `v3.0.0-rc1` to reflect the new features. (`[contracts/v2/aggchains/AggchainFEP.solL58-R72](diffhunk://#diff-45e941cbaab601c4df8af599b2c32e5726bc33b6781b6753aead91c9b80bbb3dL58-R72)`)