### PR TITLE
Fix found informationals

### DIFF
--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -571,7 +571,7 @@ contract PolygonZkEVMBridgeV2 is
         address destinationAddress,
         uint256 amount,
         bytes calldata metadata
-    ) external ifNotEmergencyState nonReentrant {
+    ) public virtual ifNotEmergencyState nonReentrant {
         // Destination network must be this networkID
         if (destinationNetwork != networkID) {
             revert DestinationNetworkInvalid();

--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -934,23 +934,15 @@ contract PolygonZkEVMBridgeV2 is
             revert GlobalExitRootInvalid();
         }
 
-        uint32 leafIndex;
-        uint32 sourceBridgeNetwork;
+        // Validate and decode global index
+        (
+            uint32 leafIndex,
+            uint32 sourceBridgeNetwork
+        ) = _validateAndDecodeGlobalIndex(globalIndex);
 
-        // Get origin network from global index
+        // Verify merkle proof based on network type
         if (globalIndex & _GLOBAL_INDEX_MAINNET_FLAG != 0) {
-            // The network is mainnet, therefore sourceBridgeNetwork is 0
-
-            // Last 32 bits are leafIndex
-            leafIndex = uint32(globalIndex);
-
-            // Reconstruct global index to assert that all unused bits are 0
-            require(
-                _GLOBAL_INDEX_MAINNET_FLAG + uint256(leafIndex) == globalIndex,
-                InvalidGlobalIndex()
-            );
-
-            // Verify merkle proof
+            // Verify merkle proof for mainnet
             if (
                 !verifyMerkleProof(
                     leafValue,
@@ -962,19 +954,8 @@ contract PolygonZkEVMBridgeV2 is
                 revert InvalidSmtProof();
             }
         } else {
-            // The network is a rollup, therefore sourceBridgeNetwork must be decoded
-            uint32 indexRollup = uint32(globalIndex >> 32);
-            sourceBridgeNetwork = indexRollup + 1;
-
-            // Last 32 bits are leafIndex
-            leafIndex = uint32(globalIndex);
-
-            // Reconstruct global index to assert that all unused bits are 0
-            require(
-                (uint256(indexRollup) << uint256(32)) + uint256(leafIndex) ==
-                    globalIndex,
-                InvalidGlobalIndex()
-            );
+            // Obtain rollup index from sourceBridgeNetwork
+            uint32 indexRollup = sourceBridgeNetwork - 1;
 
             // Verify merkle proof against rollup exit root
             if (
@@ -1151,6 +1132,43 @@ contract PolygonZkEVMBridgeV2 is
     ) internal pure returns (uint256 wordPos, uint256 bitPos) {
         wordPos = uint248(index >> 8);
         bitPos = uint8(index);
+    }
+
+    /**
+     * @notice Internal function to validate and decode global index
+     * @dev Validates global index format and extracts leafIndex and sourceBridgeNetwork
+     * @param globalIndex The global index to validate and decode
+     * @return leafIndex The leaf index extracted from global index
+     * @return sourceBridgeNetwork The source bridge network extracted from global index
+     */
+    function _validateAndDecodeGlobalIndex(
+        uint256 globalIndex
+    ) internal pure returns (uint32 leafIndex, uint32 sourceBridgeNetwork) {
+        // Last 32 bits are leafIndex
+        leafIndex = uint32(globalIndex);
+
+        // Get origin network from global index
+        if (globalIndex & _GLOBAL_INDEX_MAINNET_FLAG != 0) {
+            // The network is mainnet, therefore sourceBridgeNetwork is 0
+            sourceBridgeNetwork = 0;
+
+            // Reconstruct global index to assert that all unused bits are 0
+            require(
+                _GLOBAL_INDEX_MAINNET_FLAG + uint256(leafIndex) == globalIndex,
+                InvalidGlobalIndex()
+            );
+        } else {
+            // The network is a rollup, therefore sourceBridgeNetwork must be decoded
+            uint32 indexRollup = uint32(globalIndex >> 32);
+            sourceBridgeNetwork = indexRollup + 1;
+
+            // Reconstruct global index to assert that all unused bits are 0
+            require(
+                (uint256(indexRollup) << uint256(32)) + uint256(leafIndex) ==
+                    globalIndex,
+                InvalidGlobalIndex()
+            );
+        }
     }
 
     /**

--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -1135,7 +1135,9 @@ contract PolygonZkEVMBridgeV2 is
     /**
      * @notice Internal function to validate and decode global index
      * @dev Validates global index format and extracts leafIndex, indexRollup, and sourceBridgeNetwork
-     * @param globalIndex The global index to validate and decode
+     * @param globalIndex The global index to validate and decode, defined as:
+     * | 191 bits |    1 bit     |   32 bits   |     32 bits    |
+     * |    0     |  mainnetFlag | rollupIndex | localRootIndex |
      * @return leafIndex The leaf index extracted from global index
      * @return indexRollup The rollup index extracted from global index (0 for mainnet)
      * @return sourceBridgeNetwork The source bridge network (0 for mainnet, indexRollup + 1 for rollups)

--- a/contracts/v2/interfaces/IBridgeL2SovereignChains.sol
+++ b/contracts/v2/interfaces/IBridgeL2SovereignChains.sol
@@ -76,9 +76,9 @@ interface IBridgeL2SovereignChains is IPolygonZkEVMBridgeV2 {
     error InvalidLeavesLength();
 
     /**
-     * @dev Thrown when the expected root doesn't match the computed root
+     * @dev Thrown when the expected Local Exit Root doesn't match the computed root
      */
-    error InvalidExpectedRoot();
+    error InvalidExpectedLER();
 
     /**
      * @dev Thrown when the subtree frontier doesn't match the parent tree structure
@@ -86,12 +86,12 @@ interface IBridgeL2SovereignChains is IPolygonZkEVMBridgeV2 {
     error InvalidSubtreeFrontier();
 
     /**
-     * @dev Thrown when trying set a LFT leaf with same origin network thank chain network ID
+     * @dev Thrown when trying set a LBT leaf with same origin network than chain network ID
      */
     error InvalidLBTLeaf();
 
     /**
-     @dev Thrown when trying to substract more rather than available balance
+     @dev Thrown when trying to subtract more rather than available balance
      */
     error LocalBalanceTreeUnderflow(
         uint32 originNetwork,

--- a/contracts/v2/interfaces/IBridgeL2SovereignChains.sol
+++ b/contracts/v2/interfaces/IBridgeL2SovereignChains.sol
@@ -76,6 +76,11 @@ interface IBridgeL2SovereignChains is IPolygonZkEVMBridgeV2 {
     error InvalidLeavesLength();
 
     /**
+     * @dev Thrown when a leaf has an invalid leafType (must be _LEAF_TYPE_ASSET or _LEAF_TYPE_MESSAGE)
+     */
+    error InvalidLeafType();
+
+    /**
      * @dev Thrown when the expected Local Exit Root doesn't match the computed root
      */
     error InvalidExpectedLER();

--- a/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
+++ b/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
@@ -240,13 +240,13 @@ contract BridgeL2SovereignChain is
     event DetailedClaimEvent(
         bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] smtProofLocalExitRoot,
         bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] smtProofRollupExitRoot,
-        uint256 globalIndex,
+        uint256 indexed globalIndex,
         bytes32 mainnetExitRoot,
         bytes32 rollupExitRoot,
         uint32 originNetwork,
         address originTokenAddress,
         uint32 destinationNetwork,
-        address destinationAddress,
+        address indexed destinationAddress,
         uint256 amount,
         bytes metadata
     );
@@ -688,7 +688,7 @@ contract BridgeL2SovereignChain is
      */
     function setMultipleClaims(
         uint256[] memory globalIndexes
-    ) external onlyGlobalExitRootRemover ifEmergencyState {
+    ) external onlyGlobalExitRootRemover {
         for (uint256 i = 0; i < globalIndexes.length; i++) {
             uint256 globalIndex = globalIndexes[i];
 
@@ -803,7 +803,16 @@ contract BridgeL2SovereignChain is
         // _addLeafBridge automatically handles depositCount increment and MAX_DEPOSIT_COUNT validation
         for (uint256 i = 0; i < newLeaves.length; i++) {
             LeafData memory leaf = newLeaves[i];
-            _addLeafBridge(
+
+            // Validate leafType is either _LEAF_TYPE_ASSET or _LEAF_TYPE_MESSAGE
+            if (
+                leaf.leafType != _LEAF_TYPE_ASSET &&
+                leaf.leafType != _LEAF_TYPE_MESSAGE
+            ) {
+                revert InvalidLeafType();
+            }
+
+            super._addLeafBridge(
                 leaf.leafType,
                 leaf.originNetwork,
                 leaf.originAddress,

--- a/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
+++ b/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
@@ -625,8 +625,8 @@ contract BridgeL2SovereignChain is
 
             // Validate and decode global index using shared logic
             (
-                uint32 leafIndex,
-                , // indexRollup
+                uint32 leafIndex, // indexRollup
+                ,
                 uint32 sourceBridgeNetwork
             ) = _validateAndDecodeGlobalIndex(globalIndex);
 
@@ -661,8 +661,8 @@ contract BridgeL2SovereignChain is
 
             // Validate and decode global index using shared logic
             (
-                uint32 leafIndex,
-                , // indexRollup
+                uint32 leafIndex, // indexRollup
+                ,
                 uint32 sourceBridgeNetwork
             ) = _validateAndDecodeGlobalIndex(globalIndex);
 

--- a/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
+++ b/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
@@ -222,6 +222,7 @@ contract BridgeL2SovereignChain is
 
     /**
      * Disable initializers on the implementation following the best practices
+     * @dev the deployer is set to the contract creator and will be the only allowed to initialize the contract in a 2 steps process
      */
     constructor() PolygonZkEVMBridgeV2() {
         deployer = msg.sender;
@@ -624,8 +625,9 @@ contract BridgeL2SovereignChain is
             uint256 globalIndex = globalIndexes[i];
 
             // Validate and decode global index using shared logic
+            // second parameter: rollupIndex not used
             (
-                uint32 leafIndex, // indexRollup
+                uint32 leafIndex,
                 ,
                 uint32 sourceBridgeNetwork
             ) = _validateAndDecodeGlobalIndex(globalIndex);
@@ -660,8 +662,9 @@ contract BridgeL2SovereignChain is
             uint256 globalIndex = globalIndexes[i];
 
             // Validate and decode global index using shared logic
+            // second parameter: rollupIndex not used
             (
-                uint32 leafIndex, // indexRollup
+                uint32 leafIndex,
                 ,
                 uint32 sourceBridgeNetwork
             ) = _validateAndDecodeGlobalIndex(globalIndex);

--- a/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
+++ b/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
@@ -626,6 +626,7 @@ contract BridgeL2SovereignChain is
             // Validate and decode global index using shared logic
             (
                 uint32 leafIndex,
+                , // indexRollup
                 uint32 sourceBridgeNetwork
             ) = _validateAndDecodeGlobalIndex(globalIndex);
 
@@ -661,6 +662,7 @@ contract BridgeL2SovereignChain is
             // Validate and decode global index using shared logic
             (
                 uint32 leafIndex,
+                , // indexRollup
                 uint32 sourceBridgeNetwork
             ) = _validateAndDecodeGlobalIndex(globalIndex);
 
@@ -714,9 +716,10 @@ contract BridgeL2SovereignChain is
 
         // 2. Verify that newFrontier is a valid subtree frontier by checking it matches
         // the Merkle proof siblings at appropriate heights
-        if (!_isValidSubtreeFrontier(newDepositCount, newFrontier, proof)) {
-            revert InvalidSubtreeFrontier();
-        }
+        // NOTE: This function reverts with specific errors:
+        // - SubtreeFrontierMismatch: when frontier elements don't match proof siblings
+        // - NonZeroValueForUnusedFrontier: when unused frontier positions are not zero
+        _checkValidSubtreeFrontier(newDepositCount, newFrontier, proof);
 
         // Store previous values before rollback
         uint256 previousDepositCount = depositCount;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -226,7 +226,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 800,
+                        runs: 100,
                     },
                     evmVersion: 'shanghai', // Same evm version than BridgeL2SovereignChain
                 },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -132,7 +132,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 800, // should have same runs than BridgeL2SovereignChain
+                        runs: 100, // should have same runs than BridgeL2SovereignChain
                     },
                     evmVersion: 'shanghai',
                 },
@@ -152,7 +152,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 800, // should have same runs than PolygonZkEVMBridgeV2
+                        runs: 100, // should have same runs than PolygonZkEVMBridgeV2
                     },
                     evmVersion: 'shanghai',
                 }, // try yul optimizer
@@ -247,7 +247,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 800, // should have same runs than PolygonZkEVMBridgeV2
+                        runs: 100, // should have same runs than PolygonZkEVMBridgeV2
                     },
                     evmVersion: 'shanghai', // Same evm version than PolygonZkEVMBridgeV2
                 }, // try yul optimizer

--- a/test/contractsv2/BridgeL2SovereignChain.test.ts
+++ b/test/contractsv2/BridgeL2SovereignChain.test.ts
@@ -2832,6 +2832,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
     // Test for unsetMultipleClaims function
     it('should unsetMultipleClaims with proper permissions and validation', async () => {
+        // Activate emergency state for setMultipleClaims and unsetMultipleClaims functions
+        await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
         // Setup test data - first we need to set some claims to unset them later
         const indexLocal1 = 15;
         const indexLocal2 = 20;
@@ -2935,6 +2938,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
     // Test for setMultipleClaims function
     it('should setMultipleClaims with proper permissions and events', async () => {
+        // Activate emergency state for setMultipleClaims function
+        await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
         // Setup test data
         const indexLocal1 = 5;
         const indexLocal2 = 10;
@@ -3000,6 +3006,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
     // Test for setLocalBalanceTree function
     it('should setLocalBalanceTree with proper permissions and validation', async () => {
+        // Activate emergency state for setLocalBalanceTree function
+        await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
         // Test permission check - should fail with non-GlobalExitRootRemover
         const originNetworks = [networkIDMainnet, networkIDRollup];
         const originTokenAddresses = [ethers.ZeroAddress, polTokenContract.target];
@@ -3150,6 +3159,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should revert when newDepositCount >= currentDepositCount', async () => {
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 // First add some leaves to have a deposit count > 0
                 const leaves = generateTestLeaves(3);
                 const expectedRoot = await calculateExpectedRoot(leaves);
@@ -3176,6 +3188,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should revert when nextLeaf inclusion proof is invalid', async () => {
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 // Setup: Add some leaves to create a tree state
                 const leaves = generateTestLeaves(5);
                 const expectedRoot = await calculateExpectedRoot(leaves);
@@ -3195,6 +3210,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should revert when subtree frontier is invalid', async () => {
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 // Setup: Create a proper tree with leaves
                 const leaves = generateTestLeaves(7);
                 const tree = buildMerkleTreeForTesting(leaves);
@@ -3212,7 +3230,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
                 // Get valid proof for nextLeaf but use invalid frontier
                 const proof = tree.getProofTreeByIndex(nextLeafIndex);
@@ -3230,6 +3248,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
             it('should reject backwardLET when frontier elements mismatch proof siblings', async () => {
                 // TEST FOCUS: Validates SubtreeFrontierMismatch error when matched positions have wrong values
+
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
 
                 const leaves = generateTestLeaves(3);
                 const tree = buildMerkleTreeForTesting(leaves);
@@ -3253,7 +3274,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
                 const proof = tree.getProofTreeByIndex(newDepositCount);
 
@@ -3268,6 +3289,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             it('should validate backwardLET functionality and parameter checking', async () => {
                 // HYBRID TEST: Validates the function exists, has proper access control, and performs validation
                 // NOTE: This test focuses on parameter validation rather than successful rollback execution.
+
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
 
                 // Setup: Create a basic tree scenario to test against
                 const leaves = generateTestLeaves(3);
@@ -3293,7 +3317,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
 
                 // This validates that the function properly rejects invalid proofs
@@ -3312,6 +3336,10 @@ describe('BridgeL2SovereignChain Contract', () => {
 
             it('should validate parameter constraints and proof requirements', async () => {
                 // TEST FOCUS: Validates that backwardLET properly rejects invalid inputs and parameters
+
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 const leaves = generateTestLeaves(3);
                 const tree = buildMerkleTreeForTesting(leaves);
 
@@ -3329,7 +3357,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
 
                 // Validates that the function correctly rejects invalid proofs
@@ -3345,6 +3373,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
             it('should reject backwardLET with non-zero values in non-matched frontier positions', async () => {
                 // TEST FOCUS: Validates that frontiers with non-zero values in unused positions are rejected
+
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
 
                 const leaves = generateTestLeaves(3);
                 const tree = buildMerkleTreeForTesting(leaves);
@@ -3364,7 +3395,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     leaves[0].destinationNetwork,
                     leaves[0].destinationAddress,
                     leaves[0].amount,
-                    leaves[0].metadataHash,
+                    ethers.keccak256(leaves[0].metadata), // Convert metadata to hash
                 );
 
                 // Pollute non-matched positions with non-zero values
@@ -3380,7 +3411,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
                 const proof = tree.getProofTreeByIndex(newDepositCount);
 
@@ -3394,6 +3425,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
             it('should successfully execute backwardLET with valid subtree proof', async () => {
                 // SUCCESS TEST: Demonstrates actual backwardLET rollback from 3 leaves to 1 leaf
+
+                // Activate emergency state for forwardLET and backwardLET functions
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
 
                 const originalLeaves = generateTestLeaves(3);
                 const originalTree = buildMerkleTreeForTesting(originalLeaves);
@@ -3422,7 +3456,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     originalLeaves[0].destinationNetwork,
                     originalLeaves[0].destinationAddress,
                     originalLeaves[0].amount,
-                    originalLeaves[0].metadataHash,
+                    ethers.keccak256(originalLeaves[0].metadata), // Convert metadata to hash
                 ); // The only leaf in the subtree
 
                 // The "next leaf" is the leaf at position newDepositCount (position 1)
@@ -3434,7 +3468,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
                 // Get proof for nextLeaf at position 1 in the original tree
                 const proof = originalTree.getProofTreeByIndex(newDepositCount);
@@ -3473,6 +3507,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should revert when newLeaves array is empty', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 const emptyLeaves = [];
                 const expectedRoot = ethers.ZeroHash;
 
@@ -3482,6 +3519,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should revert when computed root doesnt match expectedStateRoot', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 const newLeaves = generateTestLeaves(3);
                 const wrongExpectedRoot = ethers.keccak256(ethers.toUtf8Bytes('wrong_root'));
 
@@ -3493,6 +3533,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should successfully add new leaves and update tree state', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 const originalDepositCount = await sovereignChainBridgeContract.depositCount();
                 const originalRoot = await sovereignChainBridgeContract.getRoot();
 
@@ -3512,6 +3555,20 @@ describe('BridgeL2SovereignChain Contract', () => {
                         originalRoot,
                         Number(originalDepositCount) + newLeaves.length,
                         expectedRoot,
+                        ethers.AbiCoder.defaultAbiCoder().encode(
+                            ['tuple(uint8,uint32,address,uint32,address,uint256,bytes)[]'],
+                            [
+                                newLeaves.map((leaf) => [
+                                    leaf.leafType,
+                                    leaf.originNetwork,
+                                    leaf.originAddress,
+                                    leaf.destinationNetwork,
+                                    leaf.destinationAddress,
+                                    leaf.amount,
+                                    leaf.metadata,
+                                ]),
+                            ],
+                        ),
                     );
 
                 // Verify state changes
@@ -3523,6 +3580,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should handle adding leaves to existing tree', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 // First add some initial leaves
                 const initialLeaves = generateTestLeaves(3);
                 const initialTree = buildMerkleTreeForTesting(initialLeaves);
@@ -3554,6 +3614,20 @@ describe('BridgeL2SovereignChain Contract', () => {
                         initialRoot,
                         Number(initialDepositCount) + additionalLeaves.length,
                         expectedFinalRoot,
+                        ethers.AbiCoder.defaultAbiCoder().encode(
+                            ['tuple(uint8,uint32,address,uint32,address,uint256,bytes)[]'],
+                            [
+                                additionalLeaves.map((leaf) => [
+                                    leaf.leafType,
+                                    leaf.originNetwork,
+                                    leaf.originAddress,
+                                    leaf.destinationNetwork,
+                                    leaf.destinationAddress,
+                                    leaf.amount,
+                                    leaf.metadata,
+                                ]),
+                            ],
+                        ),
                     );
 
                 // Verify final state
@@ -3564,6 +3638,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should handle single leaf addition', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 const originalDepositCount = await sovereignChainBridgeContract.depositCount();
                 const originalRoot = await sovereignChainBridgeContract.getRoot();
 
@@ -3575,7 +3652,26 @@ describe('BridgeL2SovereignChain Contract', () => {
                     sovereignChainBridgeContract.connect(globalExitRootRemover).forwardLET(singleLeaf, expectedRoot),
                 )
                     .to.emit(sovereignChainBridgeContract, 'ForwardLET')
-                    .withArgs(originalDepositCount, originalRoot, Number(originalDepositCount) + 1, expectedRoot);
+                    .withArgs(
+                        originalDepositCount,
+                        originalRoot,
+                        Number(originalDepositCount) + 1,
+                        expectedRoot,
+                        ethers.AbiCoder.defaultAbiCoder().encode(
+                            ['tuple(uint8,uint32,address,uint32,address,uint256,bytes)[]'],
+                            [
+                                singleLeaf.map((leaf) => [
+                                    leaf.leafType,
+                                    leaf.originNetwork,
+                                    leaf.originAddress,
+                                    leaf.destinationNetwork,
+                                    leaf.destinationAddress,
+                                    leaf.amount,
+                                    leaf.metadata,
+                                ]),
+                            ],
+                        ),
+                    );
 
                 expect(await sovereignChainBridgeContract.depositCount()).to.equal(Number(originalDepositCount) + 1);
             });
@@ -3583,6 +3679,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             it('should automatically handle MerkleTreeFull validation through _addLeaf', async () => {
                 // This test validates that the function properly delegates to _addLeaf
                 // which contains the MerkleTreeFull validation
+
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
 
                 const leaves = generateTestLeaves(2);
                 const expectedTree = buildMerkleTreeForTesting(leaves);
@@ -3598,6 +3697,9 @@ describe('BridgeL2SovereignChain Contract', () => {
 
         describe('Combined LET Operations', () => {
             it('should allow forward operations and validate access control', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 // Test forward operation works correctly
                 const forwardLeaves = generateTestLeaves(5);
                 const forwardTree = buildMerkleTreeForTesting(forwardLeaves);
@@ -3620,7 +3722,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     nextLeaf.destinationNetwork,
                     nextLeaf.destinationAddress,
                     nextLeaf.amount,
-                    nextLeaf.metadataHash,
+                    ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
                 );
                 // Verify only GlobalExitRootRemover can call backwardLET
                 await expect(
@@ -3631,6 +3733,9 @@ describe('BridgeL2SovereignChain Contract', () => {
             });
 
             it('should allow sequential forward operations', async () => {
+                // Activate emergency state for forwardLET function
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
                 // Setup initial state with 3 leaves
                 const initialLeaves = generateTestLeaves(3);
                 const initialTree = buildMerkleTreeForTesting(initialLeaves);
@@ -3676,7 +3781,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     leaf.destinationNetwork,
                     leaf.destinationAddress,
                     leaf.amount,
-                    leaf.metadataHash,
+                    ethers.keccak256(leaf.metadata), // Convert metadata to hash
                 ),
             );
             let level = 0;
@@ -3705,6 +3810,9 @@ describe('BridgeL2SovereignChain Contract', () => {
         }
 
         it('should handle edge case: rollback to empty tree (depositCount = 0)', async () => {
+            // Activate emergency state for forwardLET and backwardLET functions
+            await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
             // Add one leaf first
             const leaf = generateTestLeaves(1);
             const tree = buildMerkleTreeForTesting(leaf);
@@ -3722,7 +3830,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                 nextLeaf.destinationNetwork,
                 nextLeaf.destinationAddress,
                 nextLeaf.amount,
-                nextLeaf.metadataHash,
+                ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
             );
             await sovereignChainBridgeContract
                 .connect(globalExitRootRemover)
@@ -3733,6 +3841,10 @@ describe('BridgeL2SovereignChain Contract', () => {
 
         it('should maintain GER updates for both forward and backward operations', async () => {
             // This test ensures both operations properly update the Global Exit Root
+
+            // Activate emergency state for forwardLET and backwardLET functions
+            await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
             const leaves = generateTestLeaves(3);
             const tree = buildMerkleTreeForTesting(leaves);
 
@@ -3752,7 +3864,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                 nextLeaf.destinationNetwork,
                 nextLeaf.destinationAddress,
                 nextLeaf.amount,
-                nextLeaf.metadataHash,
+                ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
             );
             await sovereignChainBridgeContract
                 .connect(globalExitRootRemover)
@@ -3764,6 +3876,10 @@ describe('BridgeL2SovereignChain Contract', () => {
 
         it('should handle maximum valid deposit counts properly', async () => {
             // Test with reasonable number of leaves (avoid hitting actual MAX_DEPOSIT_COUNT in test)
+
+            // Activate emergency state for forwardLET and backwardLET functions
+            await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
             const reasonableMax = 10;
             const leaves = generateTestLeaves(reasonableMax);
             const tree = buildMerkleTreeForTesting(leaves);
@@ -3785,7 +3901,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                 nextLeaf.destinationNetwork,
                 nextLeaf.destinationAddress,
                 nextLeaf.amount,
-                nextLeaf.metadataHash,
+                ethers.keccak256(nextLeaf.metadata), // Convert metadata to hash
             );
             // This should fail with proper validation, confirming the function works correctly
             await expect(
@@ -3796,6 +3912,74 @@ describe('BridgeL2SovereignChain Contract', () => {
 
             // Confirm original state is maintained
             expect(await sovereignChainBridgeContract.depositCount()).to.equal(reasonableMax);
+        });
+    });
+
+    // ============= EMERGENCY STATE VALIDATION TESTS =============
+    describe('Emergency State Requirements', () => {
+        beforeEach(async () => {
+            // Ensure emergency state is deactivated before each test
+            if (await sovereignChainBridgeContract.isEmergencyState()) {
+                await sovereignChainBridgeContract.connect(emergencyBridgeUnpauser).deactivateEmergencyState();
+            }
+        });
+
+        it('should revert setMultipleClaims when emergency state is not active', async () => {
+            const globalIndexes = [computeGlobalIndex(1, 1, false)];
+
+            await expect(
+                sovereignChainBridgeContract.connect(globalExitRootRemover).setMultipleClaims(globalIndexes),
+            ).to.be.revertedWithCustomError(sovereignChainBridgeContract, 'OnlyEmergencyState');
+        });
+
+        it('should revert backwardLET when emergency state is not active', async () => {
+            const newDepositCount = 1;
+            const newFrontier = Array(32).fill(ethers.ZeroHash) as [string, ...string[]];
+            const nextLeaf = ethers.keccak256(ethers.toUtf8Bytes('test'));
+            const proof = Array(32).fill(ethers.ZeroHash) as [string, ...string[]];
+
+            await expect(
+                sovereignChainBridgeContract
+                    .connect(globalExitRootRemover)
+                    .backwardLET(newDepositCount, newFrontier, nextLeaf, proof),
+            ).to.be.revertedWithCustomError(sovereignChainBridgeContract, 'OnlyEmergencyState');
+        });
+
+        it('should revert forwardLET when emergency state is not active', async () => {
+            const newLeaves = generateTestLeaves(1);
+            const expectedRoot = ethers.ZeroHash;
+
+            await expect(
+                sovereignChainBridgeContract.connect(globalExitRootRemover).forwardLET(newLeaves, expectedRoot),
+            ).to.be.revertedWithCustomError(sovereignChainBridgeContract, 'OnlyEmergencyState');
+        });
+
+        it('should revert setLocalBalanceTree when emergency state is not active', async () => {
+            const originNetworks = [1];
+            const originTokenAddresses = [ethers.Wallet.createRandom().address];
+            const amounts = [ethers.parseEther('1')];
+
+            await expect(
+                sovereignChainBridgeContract
+                    .connect(globalExitRootRemover)
+                    .setLocalBalanceTree(originNetworks, originTokenAddresses, amounts),
+            ).to.be.revertedWithCustomError(sovereignChainBridgeContract, 'OnlyEmergencyState');
+        });
+
+        it('should allow emergency functions when emergency state is active', async () => {
+            // Activate emergency state
+            await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
+            // Test that functions now work (basic smoke tests)
+            const globalIndexes = [computeGlobalIndex(1, 1, false)];
+
+            // Should not revert with OnlyEmergencyState (may revert with other validation errors)
+            try {
+                await sovereignChainBridgeContract.connect(globalExitRootRemover).setMultipleClaims(globalIndexes);
+            } catch (error) {
+                // Should not be OnlyEmergencyState error
+                expect(error.message).to.not.include('OnlyEmergencyState');
+            }
         });
     });
 
@@ -3811,7 +3995,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                     leaf.destinationNetwork,
                     leaf.destinationAddress,
                     leaf.amount,
-                    leaf.metadataHash,
+                    ethers.keccak256(leaf.metadata), // Convert metadata to hash
                 ),
             );
         }
@@ -3829,7 +4013,7 @@ describe('BridgeL2SovereignChain Contract', () => {
                 destinationNetwork: networkIDRollup2, // destinationNetwork (same to avoid LocalBalanceTree issues)
                 destinationAddress: ethers.Wallet.createRandom().address, // destinationAddress
                 amount: ethers.parseEther(`${i + 1}`), // amount
-                metadataHash: ethers.keccak256(ethers.toUtf8Bytes(`metadata_${i}`)), // metadataHash
+                metadata: ethers.toUtf8Bytes(`metadata_${i}`), // metadata
             };
             leaves.push(leafValue);
         }


### PR DESCRIPTION
Fixed following informationals from https://github.com/agglayer/internal-audit/issues/184

- fix comment in IBridgeL2SovereignChains:InvalidLBTLeaf error
- keep permit comments present in PolygonZkEVMBridgeV2V1010.sol:_permit:1185 & PolygonZkEVMBridgeV2V1010.sol:_permit:1243
- in BridgeLib:returnDataToString is an internal function. It should be renamed as the _returnDataToString
- in DepositContractBase:_isValidSubtreeFrontier ensure that not matched siblings are zero (just to not set random values to the new frontier)
- in BridgeL2SovereignChain.sol --> events BackwardLET & ForwardLET add also the previousDepositCount& previusRoot
- in BridgeL2SovereignChain.sol:763 --> it is not the GER, is the LER. Rename to avoid confiusion.
- in BridgeL2SovereignChain.sol:779 --> it is not a stateRoot, it is a LER
- modify also error name InvalidExpectedRoot to be more explicit (like 'InvalidExpectedLER')
- fix all references to stateRoot
- in BridgeL2SovereignChain.sol:setMultipleClaims() the globalIndex is checked almost as it is checked already on the PolygonZkEVMBridgeV2.sol:_verifyLeaf -> why not create an internal function and reuse the the code to rebuild the globalIndex ?
- in BridgeL2SovereignChain.sol:setLocalBalanceTree() the originNetwork[i] == networkIDI think it is not necessary. The LBT in the SC can be corrupted at some specific leave, regardless the originNetwork